### PR TITLE
Repair problem with getConfigFiles() override

### DIFF
--- a/src/main/groovy/com/confluex/mule/test/BetterFunctionalTestCase.groovy
+++ b/src/main/groovy/com/confluex/mule/test/BetterFunctionalTestCase.groovy
@@ -39,7 +39,7 @@ abstract class BetterFunctionalTestCase extends FunctionalTestCase {
             }
             return new SpringXmlConfigurationBuilder([configResources, "testing-kit-config.xml"] as String[]);
         }
-        def multipleConfigResources = getConfigFiles() + "testing-kit-config.xml";
+        def multipleConfigResources = (getConfigFiles() as List) << "testing-kit-config.xml";
         return new SpringXmlConfigurationBuilder(multipleConfigResources as String[]);
     }
 

--- a/src/test/groovy/com/confluex/mule/test/functional/MultipleConfigsTest.groovy
+++ b/src/test/groovy/com/confluex/mule/test/functional/MultipleConfigsTest.groovy
@@ -1,0 +1,19 @@
+package com.confluex.mule.test.functional;
+
+import com.confluex.mule.test.BetterFunctionalTestCase
+import org.junit.Test;
+
+public class MultipleConfigsTest extends BetterFunctionalTestCase {
+
+    @Override
+    String[] getConfigFiles() {
+        ['mule-config-1.xml', 'mule-config-2.xml', 'mule-config-3.xml']
+    }
+
+    @Test
+    void flowsInAllConfigurationFilesShouldRun() {
+        def listener = listenForEndpoint('outbox')
+        muleContext.client.dispatch('vm://multiple.test.inbox', 'anything', [:])
+        assert listener.waitForMessages()
+    }
+}

--- a/src/test/resources/mule-config-1.xml
+++ b/src/test/resources/mule-config-1.xml
@@ -1,0 +1,23 @@
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+">
+
+    <vm:endpoint name="inbox" path="multiple.test.inbox"/>
+    <vm:endpoint name="stage1" path="multiple.test.stage1"/>
+
+    <notifications dynamic="true">
+        <notification event="ENDPOINT-MESSAGE" />
+    </notifications>
+
+    <flow name="flow-1">
+        <vm:inbound-endpoint ref="inbox" />
+        <logger category="com.confluex.mule.test.multiple" level="INFO" message="Stage 1 Processed" />
+        <vm:outbound-endpoint ref="stage1" />
+    </flow>
+</mule>

--- a/src/test/resources/mule-config-2.xml
+++ b/src/test/resources/mule-config-2.xml
@@ -1,0 +1,17 @@
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+">
+    <vm:endpoint name="stage2" path="multiple.test.stage2"/>
+
+    <flow name="flow-2">
+        <vm:inbound-endpoint ref="stage1" />
+        <logger category="com.confluex.mule.test.multiple" level="INFO" message="Stage 2 Processed" />
+        <vm:outbound-endpoint ref="stage2" />
+    </flow>
+</mule>

--- a/src/test/resources/mule-config-3.xml
+++ b/src/test/resources/mule-config-3.xml
@@ -1,0 +1,17 @@
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:vm="http://www.mulesoft.org/schema/mule/vm"
+      xmlns:spring="http://www.springframework.org/schema/beans"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="
+http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
+http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+">
+    <vm:endpoint name="outbox" path="multiple.test.outbox"/>
+
+    <flow name="flow-3">
+        <vm:inbound-endpoint ref="stage2" />
+        <logger category="com.confluex.mule.test.multiple" level="INFO" message="Stage 3 Processed" />
+        <vm:outbound-endpoint ref="outbox" />
+    </flow>
+</mule>


### PR DESCRIPTION
Fix problem with subclasses that implement @Override getConfigFiles().  Here's the stack trace this fixes:

```
groovy.lang.MissingMethodException: No signature of method: [Ljava.lang.String;.plus() is applicable for argument types: (java.lang.String) values: [testing-kit-config.xml]
Possible solutions: sum(), last(), is(java.lang.Object), sum(groovy.lang.Closure), minus([Ljava.lang.Object;), join(java.lang.String)
    at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:55)
    at org.codehaus.groovy.runtime.callsite.PojoMetaClassSite.call(PojoMetaClassSite.java:46)
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:42)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:116)
    at com.confluex.mule.test.BetterFunctionalTestCase.getBuilder(BetterFunctionalTestCase.groovy:42)
    at org.mule.tck.junit4.AbstractMuleContextTestCase.createMuleContext(AbstractMuleContextTestCase.java:235)
    at com.confluex.mule.test.BetterFunctionalTestCase.super$3$createMuleContext(BetterFunctionalTestCase.groovy)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90)
    at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:233)
    at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1047)
    at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.invokeMethodOnSuperN(ScriptBytecodeAdapter.java:128)
    at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.invokeMethodOnSuper0(ScriptBytecodeAdapter.java:148)
    at com.confluex.mule.test.BetterFunctionalTestCase.createMuleContext(BetterFunctionalTestCase.groovy:49)
    at org.mule.tck.junit4.AbstractMuleContextTestCase.setUpMuleContext(AbstractMuleContextTestCase.java:145)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
    at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:24)
    at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
    at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
    at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.lang.Thread.run(Thread.java:745)
```
